### PR TITLE
Enable speed/temperature multiplexing on same wire

### DIFF
--- a/Inc/main.h
+++ b/Inc/main.h
@@ -185,8 +185,8 @@ typedef struct
 typedef struct
 {
 
-	uint16_t       	num;
-	uint16_t       	denum;
+	uint32_t       	num;
+	uint32_t       	denum;
 
 
 }NTC_Mult_t;

--- a/Inc/main.h
+++ b/Inc/main.h
@@ -92,6 +92,7 @@
 #define BATTERYVOLTAGE_MAX 41500
 #define R_TEMP_PULLUP 0
 #define NTC_BETA 3900
+#define SP_TEMP_MULTIPLEX 0 // high-pass ADC value on NTC-Hall multiplexed wire
 
 /* ########################## Assert Selection ############################## */
 /**

--- a/Inc/main.h
+++ b/Inc/main.h
@@ -91,6 +91,7 @@
 #define LEGALFLAG
 #define BATTERYVOLTAGE_MAX 41500
 #define R_TEMP_PULLUP 0
+#define NTC_BETA 3900
 
 /* ########################## Assert Selection ############################## */
 /**
@@ -178,6 +179,19 @@ typedef struct
 
 
 }MotorParams_t;
+
+#ifdef R_TEMP_PULLUP
+
+typedef struct
+{
+
+	uint16_t       	num;
+	uint16_t       	denum;
+
+
+}NTC_Mult_t;
+
+#endif
 
 /* USER CODE END Private defines */
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -208,6 +208,10 @@ uint16_t VirtAddVarTab[NB_OF_VAR] = { 	EEPROM_POS_HALL_ORDER,
 		EEPROM_POS_HALL_64
 	};
 
+#if R_TEMP_PULLUP
+uint16_t ui16_adc_temp;
+#endif
+
 enum state {Stop, SixStep, Regen, Running, BatteryCurrentLimit, Interpolation, PLL, IdleRun};
 enum state SystemState;
 
@@ -589,7 +593,7 @@ int main(void)
 
  // Calculate multipliers for NTC 10k Beta value
 #if (R_TEMP_PULLUP)
-	set_NTC_beta();
+    set_NTC_beta();
 #endif
 
   /* USER CODE END 2 */
@@ -969,7 +973,11 @@ int main(void)
 
 		  if(ui8_KV_detect_flag){ui16_KV_detect_counter++;}
 #if (R_TEMP_PULLUP)
-		  MS.Temperature = T_NTC(adcData[6]); //Thank you Hendrik ;-)
+          ui16_adc_temp = adcData[6]; // adcData[5] on LSW12G
+#if (SP_TEMP_MULTIPLEX)               // ADC needs to be above this value to register temperature
+          if (ui16_adc_temp > SP_TEMP_MULTIPLEX) // 150 is a good starting point with 220R pull-up
+#endif
+          MS.Temperature = T_NTC(ui16_adc_temp); //Thank you Hendrik ;-)
 #else
 		  MS.Temperature=25;
 #endif

--- a/Start_Compiling.bat
+++ b/Start_Compiling.bat
@@ -23,7 +23,7 @@ copy STLINK_system_stm32f1xx.c ..\Src\system_stm32f1xx.c
 
 make all
 
-ST-LINK_CLI.exe -c SWD -P LishuiFOC_01.hex -V
+ST-LINK_CLI.exe -c SWD SWCLK=8 -P LishuiFOC_01.hex -V
 
 pause
 

--- a/WriteOptionBytes.bat
+++ b/WriteOptionBytes.bat
@@ -1,6 +1,6 @@
 PATH = %PATH%;%1\STM32 ST-LINK Utility\ST-LINK Utility
 
-ST-LINK_CLI.exe -OB RDP=0
+ST-LINK_CLI.exe -c SWD SWCLK=8 -OB RDP=0
 
 pause
 


### PR DESCRIPTION
Enables speed and temperature multiplexing on the same (usually white) wire. Works with 10k NTC thermistor with customizable Beta value. To retrofit into existing motor with speed sensor, connect NTC between black (negative) and white (speed sensor) wire in the motor. On controller side, bridge SS (speed sensor) to MOTOR_TEMPERATURE pins and one lead of 220ohm resistor. Connect the other end of resistor to 3.3v source on the board (1117 voltage regulator or analog reference pin).

Set R_TEMP_PULLUP to combined resistance of built-in pullup and 220ohm resistor - you could measure the resistance between 3.3v point and white wire when it is not connected to motor.

Set NTC_BETA to Beta value of NTC 10k thermistor in the motor. 

Set SP_TEMP_MULTIPLEX to ADC threshold for pull-down (speed sensor hall) signal. Good starting point is 200.